### PR TITLE
2회차 스터디 후 src/1week 리팩터링하기

### DIFF
--- a/src/1week/01.js
+++ b/src/1week/01.js
@@ -1,7 +1,7 @@
 var x = 2;
 
-function lineFunction() {
-  return 2 * x + 3;
+function lineFunction(xParam = x) {
+  return 2 * xParam + 3;
 }
 
 exports.lineFunction = lineFunction;

--- a/src/1week/02.js
+++ b/src/1week/02.js
@@ -1,11 +1,7 @@
+const sum = (a, b) => a + b;
+
 function accumulate(arr) {
-  let accumulator = 0;
-
-  for (let i = 0; i < arr.length; i++) {
-    accumulator += arr[i];
-  }
-
-  return accumulator;
+  return arr.reduce(sum, 0);
 }
 
 exports.accumulate = accumulate;

--- a/src/1week/03.js
+++ b/src/1week/03.js
@@ -1,10 +1,14 @@
-function multiDimensionalAccumulate(multiDimensionalArr) {
+function multiDimensionalArrayCondition ({row, column}) {
+  return column < row;
+}
+
+function multiDimensionalAccumulate(multiDimensionalArray) {
   let accumulator = 0;
 
-  for (let i = 0; i < multiDimensionalArr.length; i++) {
-    for (let j = 0; j < multiDimensionalArr[i].length; j++) {
-      if (j < i) {
-        accumulator += multiDimensionalArr[i][j];
+  for (let i = 0; i < multiDimensionalArray.length; i++) {
+    for (let j = 0; j < multiDimensionalArray[i].length; j++) {
+      if (multiDimensionalArrayCondition({row: i, column: j})) {
+        accumulator += multiDimensionalArray[i][j];
       }
     }
   }

--- a/src/1week/04.js
+++ b/src/1week/04.js
@@ -1,15 +1,17 @@
+function convertUpperCase(stringParam) {
+  return stringParam.toUpperCase();
+}
+
+function convertLowerCase(stringParam) {
+  return stringParam.toLowerCase();
+}
+
+function isLongWord(word) {
+  return word.length > 5;
+}
+
 function convertToConditionalUpperCase(words) {
-  let capitalized = [];
-
-  for (let i = 0; i < words.length; i++) {
-    if (words[i].length > 5) {
-      capitalized.push(words[i].toUpperCase());
-    } else {
-      capitalized.push(words[i].toLowerCase());
-    }
-  }
-
-  return capitalized;
+  return words.map(word => isLongWord(word) ? convertUpperCase(word) : convertLowerCase(word));
 }
 
 exports.convertToConditionalUpperCase = convertToConditionalUpperCase;


### PR DESCRIPTION
# TL;DR

- [x] 01.js
- [x] 02.js
- [x] 03.js
- [x] 04.js
- [ ] 05.js

<br />

# Description

### 01.js

전역 변수를 사용하는 `암묵적 입력`을 인자로 옮겨 `명시적 입력`으로 전환했습니다.
그리고 그러면 해당 함수를 사용하는 곳에서 인수를 작성해야하는 상황이되는데 이를 막고자 `기본값 매개변수`를 활용하여 동작에 변경이 없도록 하였습니다.

### 02.js

계산함수 분리하기에 해당한다고 생각되어 배열요소를 알아야하는 부분과 아닌 부분을 분리하였습니다.
만약 배열요소의 구조가 변경되면 sum 함수만 변경하는 이점을 갖습니다.

### 03.js

조건문은 언제든 변할 수 있고 어디서든 동일하게 적용할 수 있다고 생각되어 계산으로 추출했습니다.
아쉬운 점은 multiDimensionalAccmulate 함수가 배열을 이중으로 순회하고 있는데 이를 한번 순회하는 함수를 중첩해서 사용하는 식으로 빼내보고 싶었습니다. 즉, 사용하는 곳에서 이중 배열이든 이중 객체든 신경안써도 되는 형태로 구현하고 싶었습니다.

### 04.js

계산에서 더 낮은 계산식으로 추출했습니다.
그리고 변경될 수 있는 비즈니스 조건을 계산으로 추출했습니다.
- 문자열이 5이상인가
- 전체를 대문자로 할 것인가
- 전체를 소문자로 할 것인가

### 05.js